### PR TITLE
Update reference and add format examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Webster's Unabridged English Dictionary
 
-This repository contains *Webster's Unabridged English Dictionary* (from the [Gutenberg Project](https://www.gutenberg.org/)) in several formats:
+This repository contains [*Webster's Unabridged English Dictionary*](https://www.gutenberg.org/ebooks/29765) (from the [Gutenberg Project](https://www.gutenberg.org/), compiled August 22, 2009) in several formats:
 
 | Format | File |
 | --- | --- |
@@ -26,6 +26,32 @@ Example: `./WebstersEnglishDictionary WebstersEnglishDictionary.txt ~/Documents/
 
 - The JSON files can be used as-is. Any project which can parse JSON should be able to read and process these files
 - Keep in mind that the size of these files is significant: you may wish to implement your own optimizations to either the output (for improved sorting / lookup) or compression if you are including the files in bundled applications
+
+## Formatting
+### `dictionary.json`
+A single object of all words and definitions
+```json
+{
+  "anopheles" : "A genus of mosquitoes which are secondary hosts of the malaria parasites, and whose bite is the usual, if not the only, means of infecting human beings with malaria. Several species are found in the United States. They may be distinguished from the ordinary mosquitoes of the genus Culex by the long slender palpi, nearly equaling the beak in length, while those of the female Culex are very short. They also assume different positions when resting, Culex usually holding the body parallel to the surface on which it rests and keeping the head and beak bent at an angle, while Anopheles holds the body at an angle with the surface and the head and beak in line with it. Unless they become themselves infected by previously biting a subject affected with malaria, the insects cannot transmit the disease.",
+  "uniclinal" : "See Nonoclinal.",
+  "sarong" : "A sort of petticoat worn by both sexes in Java and the Malay Archipelago. Balfour (Cyc. of India)",
+```
+
+### `dictionary_alpha_arrays.json`
+An array of 26 objects, for each leading letter
+```json
+[
+  {
+    "anarchic" : "Pertaining to anarchy; without rule or government; in political confusion; tending to produce anarchy; as, anarchic despotism; anarchical opinions.",
+    "anopheles" : "A genus of mosquitoes which are secondary hosts of the malaria parasites, and whose bite is the usual, if not the only, means of infecting human beings with malaria. Several species are found in the United States. They may be distinguished from the ordinary mosquitoes of the genus Culex by the long slender palpi, nearly equaling the beak in length, while those of the female Culex are very short. They also assume different positions when resting, Culex usually holding the body parallel to the surface on which it rests and keeping the head and beak bent at an angle, while Anopheles holds the body at an angle with the surface and the head and beak in line with it. Unless they become themselves infected by previously biting a subject affected with malaria, the insects cannot transmit the disease.",
+    "anti-federalist" : "One of party opposed to a federative government; -- applied particularly to the party which opposed the adoption of the constitution of the United States. Pickering.",
+```
+
+### `dictionary_compact.json`
+Same format as `dictionary.json`, with extraneous whitespace removed
+```json
+{"anopheles":"A genus of mosquitoes which are secondary hosts of the malaria parasites, and whose bite is the usual, if not the only, means of infecting human beings with malaria. Several species are found in the United States. They may be distinguished from the ordinary mosquitoes of the genus Culex by the long slender palpi, nearly equaling the beak in length, while those of the female Culex are very short. They also assume different positions when resting, Culex usually holding the body parallel to the surface on which it rests and keeping the head and beak bent at an angle, while Anopheles holds the body at an angle with the surface and the head and beak in line with it. Unless they become themselves infected by previously biting a subject affected with malaria, the insects cannot transmit the disease.","uniclinal":"See Nonoclinal.","sarong":"A sort of petticoat worn by both sexes in Java and the Malay Archipelago. Balfour (Cyc. of India)",
+```
 
 ## Acknowledgments
 


### PR DESCRIPTION
Adds a link to the specific Gutenberg ebook, and notes its creation date. Adds file snippets, so curious can see file formatting without opening chunky files